### PR TITLE
height to outerHeight; hiding the action button

### DIFF
--- a/client/html/themes/aimeos.js
+++ b/client/html/themes/aimeos.js
@@ -682,6 +682,7 @@ AimeosBasketStandard = {
 
 		$("body").on("focusin", ".basket-standard .basket .product .quantity .value", {}, function(ev) {
 			$(".btn-update", ev.delegateTarget).show();
+			$(".btn-action", ev.delegateTarget).hide();
 		});
 	},
 
@@ -1298,7 +1299,7 @@ AimeosCatalogList = {
 
 			if( list.length > 1 ) {
 				var second = list.eq(1);
-				var size = $(this).height();
+				var size = $(this).outerHeight();
 				var image = $("img", second);
 
 				$(this).css("background-image", "none"); // Don't let default image shine through


### PR DESCRIPTION
Using outerHeight, you include the size of the border. (Try with a product image where the background is not white and a second product image where the background is white. Then you will notice that the first image is still visible a bit.)
Hide the action button on the cart at the same time when the update button is displayed.